### PR TITLE
Fix segfault on owdir /uncached/XXX

### DIFF
--- a/module/owlib/src/c/ow_moat.c
+++ b/module/owlib/src/c/ow_moat.c
@@ -221,6 +221,9 @@ static enum e_visibility FS_show_one_config( const struct parsedname * pn )
 static enum e_visibility FS_show_s_entry( const struct parsedname * pn )
 {
 	BYTE buf[M_MAX];
+	if(IsDir(pn))
+		return visible_now;
+
 	if (pn->selected_filetype->data.u >= M_MAX)
 		return visible_never;
 


### PR DESCRIPTION
I got a segfault while doing owdir in /uncached/F0.D6A1EC80F600:

```
   CALL: ow_parsename.c:(104) path=[/uncached/F0.D6A1EC80F600/status]
  DEBUG: ow_regex.c:(154) Not found
  DEBUG: ow_regex.c:(154) Not found
  DEBUG: ow_regex.c:(201) 0: 0->15 found <><F0.D6A1EC80F600><>
  DEBUG: ow_regex.c:(201) 1: 0->2 found <><F0><.D6A1EC80F600>
  DEBUG: ow_regex.c:(201) 2: 3->15 found <F0.><D6A1EC80F600><>
  DEBUG: ow_cache.c:(912) Looking for device F0 D6 A1 EC 80 F6 00 C6
  DEBUG: ow_cache.c:(1070) Search in cache sn F0 D6 A1 EC 80 F6 00 C6 pointer=0x800b31794 index=0 size=4
  DEBUG: ow_cache.c:(1086) Value found in cache. Remaining life: 120 seconds.
  DEBUG: ow_presence.c:(75) Found device on bus 0
  DEBUG: ow_regex.c:(154) Not found
[New Thread 802411400 (LWP 102350/owserver)]

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 802411400 (LWP 102350/owserver)]
0x00000008008bf9f7 in FS_show_s_entry (pn=0x7fffff7f0dc8) at ow_moat.c:224
224             if (pn->selected_filetype->data.u >= M_MAX)
Current language:  auto; currently minimal
(gdb) where
#0  0x00000008008bf9f7 in FS_show_s_entry (pn=0x7fffff7f0dc8) at ow_moat.c:224
#1  0x00000008008a1c8b in FS_devdir () at ow_dir.c:875
#2  0x00000008008a10e4 in FS_dir_both (dirfunc=0x403140 <DirallHandlerCallback>, v=0x7fffff7fb260, pn_raw_directory=0x7fffff7fb2d0, flags=<value optimized out>) at ow_dir.c:135
#3  0x0000000000403225 in DirallHandler (hd=<value optimized out>, cm=0x7fffff7fbf70, pn=0x7fffff7fb2d0) at dirall.c:72
#4  0x0000000000403b74 in DataHandler (v=0x7fffff9fced8) at data.c:164
#5  0x000000080117c4f5 in pthread_create () from /lib/libthr.so.3
#6  0x0000000000000000 in ?? ()
(gdb) print *pn
$2 = {path = "/uncached/F0.D6A1EC80F600/status", '\0' <repeats 2017 times>, path_to_server = "/uncached/F0.D6A1EC80F600/status", '\0' <repeats 993 times>, 
  device_name = 0x7fffff7f0dd2 "F0.D6A1EC80F600/status", known_bus = 0x801c21200, type = ePN_real, state = 9, sn = "?200?\000, selected_device = 0x801c19190, selected_filetype = 0x0, 
  extension = 0, sparse_name = 0x0, subdir = 0x800b2d750, dirlength = 26, ds2409_depth = 0, bp = 0x0, selected_connection = 0x801c21200, control_flags = 330, lock = 0x0, return_code = 0, 
  detail_flag = 0, tokens = 0, tokenstring = 0x0}
```

As the MOAT filetype is setup now, it seems to make sense to always show the entry if it is a directory?

Weird though, I wonder why this haven't popped earlier during development.. It seems like a pretty standard command to test with?
